### PR TITLE
linear_decay: multiply linear scale to init_value

### DIFF
--- a/lib/polaris/schedules.ex
+++ b/lib/polaris/schedules.ex
@@ -44,11 +44,14 @@ defmodule Polaris.Schedules do
         steps: 1000
       )
 
-    if step < opts[:warmup] do
-      step / Nx.max(1, opts[:warmup])
-    else
-      Nx.max(0.0, (opts[:steps] - step) / Nx.max(1, opts[:steps] - opts[:warmup]))
-    end
+    scale =
+      if step < opts[:warmup] do
+        step / Nx.max(1, opts[:warmup])
+      else
+        Nx.max(0.0, (opts[:steps] - step) / Nx.max(1, opts[:steps] - opts[:warmup]))
+      end
+
+    scale * opts[:init_value]
   end
 
   @doc ~S"""


### PR DESCRIPTION
Linear decay schedule always returns a number in the range `0..1` it never takes into account the learning rate (init_value).

For example, plotting:

```
scheduler = Polaris.Schedules.linear_decay(0.06, steps: 100)

steps = 0..100
lrs = for step <- steps, do: Nx.to_number(scheduler.(step))

scheduler_lr = %{
  x: steps,
  y: lrs
}
```

<img width="269" alt="Screenshot 2023-11-05 at 17 16 31" src="https://github.com/elixir-nx/polaris/assets/1815076/f5513c21-777c-45d6-bdf4-647b8439a8bb">

With the warmup parameter, same issue:

```
scheduler = Polaris.Schedules.linear_decay(0.06, steps: 100, warmup: 20)
```

<img width="274" alt="Screenshot 2023-11-05 at 17 17 51" src="https://github.com/elixir-nx/polaris/assets/1815076/2e94d085-b7b3-45f4-8c3c-688f74ee4862">

With the fix:

<img width="278" alt="Screenshot 2023-11-05 at 17 19 05" src="https://github.com/elixir-nx/polaris/assets/1815076/c004004a-fbac-404b-9b30-0fdc8a3a47b4">

<img width="275" alt="Screenshot 2023-11-05 at 17 19 19" src="https://github.com/elixir-nx/polaris/assets/1815076/a36a0cb7-3091-4d4a-a716-f156c799c226">


