### PR TITLE
Implements cosine decay with linear warmup

### DIFF
--- a/lib/polaris/schedules.ex
+++ b/lib/polaris/schedules.ex
@@ -151,6 +151,65 @@ defmodule Polaris.Schedules do
     init_value * (cos + alpha)
   end
 
+  @doc """
+  Cosine decay schedule with linear warmup.
+
+  For steps within the warmup period, the learning rate increases linearly. After the warmup period, it follows a cosine decay schedule:
+
+  $$
+  \gamma(t) = 
+  \begin{cases} 
+  \frac{t}{\text{warmup\_steps}} * \gamma_{\text{peak}} & \text{if } t < \text{warmup\_steps} \\
+  \gamma_{\text{peak}} * \left(\frac{1}{2}(1 - \alpha)(1 + \cos\pi \frac{t - \text{warmup\_steps}}{k}) + \alpha\right) & \text{otherwise}
+  \end{cases}
+  $$
+
+  ## Options
+
+  * `:warmup_steps` - number of warmup steps during which the learning rate increases linearly.
+
+  * `:decay_steps` - number of steps to apply decay for.
+    $k$ in the above formulation. Defaults to `10`.
+
+  * `:alpha` - minimum multiplier value for adjusting the learning rate.
+    $\alpha$ in the above formulation. Defaults to `0.0`.
+  """
+  def warmup_cosine_decay(init_value, opts \\ []) do
+    &apply_warmup_cosine_decay(&1, [{:init_value, init_value} | opts])
+  end
+
+  defnp apply_warmup_cosine_decay(step, opts \\ []) do
+    opts =
+      keyword!(opts,
+        init_value: nil,
+        warmup_steps: 10,
+        decay_steps: 10,
+        alpha: 0.0
+      )
+
+    init_value = opts[:init_value]
+    warmup_steps = opts[:warmup_steps]
+    decay_steps = opts[:decay_steps]
+    alpha = opts[:alpha]
+
+    # Linear warmup phase
+    warmup_rate = init_value / warmup_steps
+    warmup = warmup_rate * Nx.min(step, warmup_steps)
+
+    # Cosine decay phase
+    decay_step = Nx.max(step - warmup_steps, 0)
+    theta = Nx.min(decay_step, decay_steps) / decay_steps * Nx.Constants.pi()
+    cos_decay = (Nx.cos(theta) + 1) / 2
+    decay = init_value * (cos_decay * (1 - alpha) + alpha)
+
+    # Choose between warmup and decay based on step
+    Nx.select(
+      Nx.less(step, warmup_steps),
+      warmup,
+      decay
+    )
+  end
+
   @doc ~S"""
   Constant schedule.
 


### PR DESCRIPTION
This pull request introduces a new cosine decay schedule with linear warmup to the `Polaris.Schedules` module and adds corresponding tests to ensure its functionality. 

### New Feature: Cosine Decay Schedule with Linear Warmup

* [`lib/polaris/schedules.ex`](diffhunk://#diff-87241e7cbce7ccc2bac09bb593a31a25edd73faf2971bee35717ca7560c66160R154-R212): Added the `warmup_cosine_decay` function, which implements a learning rate schedule that first increases linearly during a warmup period and then follows a cosine decay pattern. This function includes detailed documentation and options for customization.

### Tests for New Feature

* [`test/polaris/schedules_test.exs`](diffhunk://#diff-7bdf3d15ade5de6fbb35769461967462d7aa537ad48e16e379139e4ffb5ada47R122-R176): Added a series of tests for the `warmup_cosine_decay` function to verify its behavior, including tests for correct function arity, linear warmup phase, cosine decay phase, and respect for the `alpha` parameter.